### PR TITLE
Add docs and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
 - [🚀 Getting started](#-getting-started)
 - [🤖 Compatibility with MeiliSearch](#-compatibility-with-meilisearch)
 - [🎬 Examples](#-examples)
+  - [Client](#client)
   - [Indexes](#indexes)
   - [Documents](#documents)
   - [Update status](#update-status)
@@ -116,6 +117,21 @@ This package is compatible with the following MeiliSearch versions:
 
 All HTTP routes of MeiliSearch are accessible via methods in this SDK.</br>
 You can check out [the API documentation](https://docs.meilisearch.com/references/).
+
+### Client
+
+```ruby
+# Default client
+client = MeiliSearch::Client.new('http://127.0.0.1:7700', 'masterKey')
+# Custom client
+client = MeiliSearch::Client.new('http://127.0.0.1:7700', 'masterKey', timeout: 2, max_retries: 2)
+```
+
+`timeout` - default value: `1` second<br>
+The time in seconds before a `Timeout::Error` is raised.
+
+`max_retries` - default value: `0`<br>
+If the HTTP request times out, this number of retries will be applied.
 
 ### Indexes
 

--- a/lib/meilisearch/http_request.rb
+++ b/lib/meilisearch/http_request.rb
@@ -69,7 +69,7 @@ module MeiliSearch
         query: query_params,
         body: body,
         timeout: @options[:timeout] || 1,
-        max_retries: @options[:max_retries] || 1
+        max_retries: @options[:max_retries] || 0
       }.compact
     end
 

--- a/spec/meilisearch_spec.rb
+++ b/spec/meilisearch_spec.rb
@@ -11,4 +11,11 @@ RSpec.describe MeiliSearch do
       client.indexes
     end.to raise_error(MeiliSearch::CommunicationError)
   end
+
+  it 'allows to set a custom timeout and max_retries' do
+    client = MeiliSearch::Client.new($URL, $MASTER_KEY, timeout: 0, max_retries: 2)
+    expect do
+      client.indexes
+    end.to raise_error(Timeout::Error)
+  end
 end


### PR DESCRIPTION
I added tests and docs to your PR if you agree.

I also change the `max_retries` default value to `0` because 1 = one retry => the retries are enable by default. To disable the retries by default we should set it to 0.
Httparty indeed accepts `0` as value for `max_retries`. See:
https://github.com/jnunemaker/httparty/blob/b9a54d8f73a9a94863bf83a1ba559b557c68b4c8/spec/httparty/connection_adapter_spec.rb#L427-L434
and
https://github.com/jnunemaker/httparty/blob/b9a54d8f73a9a94863bf83a1ba559b557c68b4c8/lib/httparty/connection_adapter.rb#L186-L188